### PR TITLE
Symfony 2.7+ compliancy change (OptionResolver API changes)

### DIFF
--- a/src/Extension/AbstractOrderedExtension.php
+++ b/src/Extension/AbstractOrderedExtension.php
@@ -33,7 +33,7 @@ abstract class AbstractOrderedExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver
             ->setDefaults(array('position' => null))


### PR DESCRIPTION
Change to make bundle compliant with symfony 2.7+ according to:
http://symfony.com/blog/new-in-symfony-2-7-form-and-validator-updates#deprecated-setdefaultoptions-in-favor-of-configureoptions