### PR TITLE
Fix deprecations

### DIFF
--- a/src/Extension/AbstractOrderedExtension.php
+++ b/src/Extension/AbstractOrderedExtension.php
@@ -36,6 +36,7 @@ abstract class AbstractOrderedExtension extends AbstractTypeExtension
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver
+            ->setDefined(array('position'))
             ->setDefaults(array('position' => null))
             ->setAllowedTypes('position', array('null', 'string', 'array'));
     }

--- a/src/Extension/AbstractOrderedExtension.php
+++ b/src/Extension/AbstractOrderedExtension.php
@@ -37,6 +37,6 @@ abstract class AbstractOrderedExtension extends AbstractTypeExtension
     {
         $resolver
             ->setDefaults(array('position' => null))
-            ->setAllowedTypes(array('position' => array('null', 'string', 'array')));
+            ->setAllowedTypes('position', array('null', 'string', 'array'));
     }
 }

--- a/src/Extension/AbstractOrderedExtension.php
+++ b/src/Extension/AbstractOrderedExtension.php
@@ -13,7 +13,7 @@ namespace Ivory\OrderedForm\Extension;
 
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Abstract ordered extension.
@@ -33,7 +33,7 @@ abstract class AbstractOrderedExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver
             ->setDefaults(array('position' => null))

--- a/src/Extension/OrderedButtonExtension.php
+++ b/src/Extension/OrderedButtonExtension.php
@@ -10,6 +10,7 @@
  */
 
 namespace Ivory\OrderedForm\Extension;
+use Symfony\Component\Form\Extension\Core\Type\ButtonType;
 
 /**
  * Ordered form button extension.
@@ -24,6 +25,6 @@ class OrderedButtonExtension extends AbstractOrderedExtension
     */
     public function getExtendedType()
     {
-        return 'button';
+        return ButtonType::class;
     }
 }

--- a/src/Extension/OrderedButtonExtension.php
+++ b/src/Extension/OrderedButtonExtension.php
@@ -10,7 +10,6 @@
  */
 
 namespace Ivory\OrderedForm\Extension;
-use Symfony\Component\Form\Extension\Core\Type\ButtonType;
 
 /**
  * Ordered form button extension.
@@ -25,6 +24,6 @@ class OrderedButtonExtension extends AbstractOrderedExtension
     */
     public function getExtendedType()
     {
-        return ButtonType::class;
+        return 'Symfony\Component\Form\Extension\Core\Type\ButtonType';
     }
 }

--- a/src/Extension/OrderedFormExtension.php
+++ b/src/Extension/OrderedFormExtension.php
@@ -10,6 +10,7 @@
  */
 
 namespace Ivory\OrderedForm\Extension;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
 
 /**
  * Ordered form extension.
@@ -23,6 +24,6 @@ class OrderedFormExtension extends AbstractOrderedExtension
      */
     public function getExtendedType()
     {
-        return 'form';
+        return FormType::class;
     }
 }

--- a/src/Extension/OrderedFormExtension.php
+++ b/src/Extension/OrderedFormExtension.php
@@ -10,7 +10,6 @@
  */
 
 namespace Ivory\OrderedForm\Extension;
-use Symfony\Component\Form\Extension\Core\Type\FormType;
 
 /**
  * Ordered form extension.
@@ -24,6 +23,6 @@ class OrderedFormExtension extends AbstractOrderedExtension
      */
     public function getExtendedType()
     {
-        return FormType::class;
+        return 'Symfony\Component\Form\Extension\Core\Type\FormType';
     }
 }


### PR DESCRIPTION
This pull request fixes three deprecations:

- `setDefaultOptions()` should be replaced with `configureOptions()`
- Type extension should return the fully-qualified class name of the extended type from `FormTypeExtensionInterface::getExtendedType()` now. ([source](https://github.com/symfony/symfony/blob/v2.8.0-BETA1/UPGRADE-2.8.md#form))
- `setAllowedTypes()` signature changed. It should be called once per key.