### PR TITLE
Make base code compatible with Symfony3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,22 +6,20 @@ php:
     - 5.4
     - 5.5
     - 5.6
+    - 7.0
     - hhvm
-    - hhvm-nightly
 
 env:
     global:
         - COMPOSER_PREFER_LOWEST=false
+        - SYMFONY_DEPRECATIONS_HELPER=weak
         - SYMFONY_VERSION=2.3.*
-
-cache:
-    directories:
-        - vendor
-        - $HOME/.composer/cache
+        - SYMFONY_PHPUNIT_BRIDGE_VERSION=2.7.*
 
 install:
     - composer self-update
     - composer require --no-update symfony/form:${SYMFONY_VERSION}
+    - composer require --dev --no-update symfony/phpunit-bridge:${SYMFONY_PHPUNIT_BRIDGE_VERSION}
     - if [[ "$SYMFONY_VERSION" = *dev* ]]; then sed -i "s/\"MIT\"/\"MIT\",\"minimum-stability\":\"dev\"/g" composer.json; fi
     - composer update --prefer-source `if [[ $COMPOSER_PREFER_LOWEST = true ]]; then echo "--prefer-lowest --prefer-stable"; fi`
 
@@ -32,7 +30,9 @@ after_script: bin/coveralls -v
 matrix:
     include:
         - php: 5.6
-          env: COMPOSER_PREFER_LOWEST=true
+          env: SYMFONY_VERSION=2.3.* COMPOSER_PREFER_LOWEST=true
+        - php: 5.6
+          env: SYMFONY_VERSION=3.0.* SYMFONY_PHPUNIT_BRIDGE_VERSION=3.0.* COMPOSER_PREFER_LOWEST=true
         - php: 5.6
           env: SYMFONY_VERSION=2.4.*
         - php: 5.6
@@ -40,10 +40,15 @@ matrix:
         - php: 5.6
           env: SYMFONY_VERSION=2.6.*
         - php: 5.6
-          env: SYMFONY_VERSION=2.7.*@dev
+          env: SYMFONY_VERSION=2.7.*
+        - php: 5.6
+          env: SYMFONY_VERSION=2.8.* SYMFONY_PHPUNIT_BRIDGE_VERSION=2.8.* SYMFONY_DEPRECATIONS_HELPER=strict
+        - php: 5.6
+          env: SYMFONY_VERSION=3.0.* SYMFONY_PHPUNIT_BRIDGE_VERSION=3.0.* SYMFONY_DEPRECATIONS_HELPER=strict
+        - php: 5.6
+          env: SYMFONY_VERSION=3.0.*@dev SYMFONY_PHPUNIT_BRIDGE_VERSION=3.0.*@dev SYMFONY_DEPRECATIONS_HELPER=strict
     allow_failures:
-        - php: hhvm-nightly
-        - env: SYMFONY_VERSION=2.7.*@dev
+        - env: SYMFONY_VERSION=3.0.*@dev SYMFONY_PHPUNIT_BRIDGE_VERSION=3.0.*@dev SYMFONY_DEPRECATIONS_HELPER=strict
 
 notifications:
     email: geloen.eric@gmail.com

--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,12 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/form": "~2.3"
+        "symfony/form": "^2.3|^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0",
-        "satooshi/php-coveralls": "~0.6"
+        "phpunit/phpunit": "^4.0",
+        "satooshi/php-coveralls": "^0.6",
+        "symfony/phpunit-bridge": "^2.7|^3.0"
     },
     "autoload": {
         "psr-4": { "Ivory\\OrderedForm\\": "src/" }

--- a/src/Extension/AbstractOrderedExtension.php
+++ b/src/Extension/AbstractOrderedExtension.php
@@ -13,6 +13,7 @@ namespace Ivory\OrderedForm\Extension;
 
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
@@ -31,12 +32,24 @@ abstract class AbstractOrderedExtension extends AbstractTypeExtension
     }
 
     /**
+     * @param OptionsResolver $resolver
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array('position' => null));
+
+        if (method_exists('Symfony\Component\Form\AbstractType', 'configureOptions')) {
+            $resolver->setAllowedTypes('position', array('null', 'string', 'array'));
+        } else {
+            $resolver->setAllowedTypes(array('position' => array('null', 'string', 'array')));
+        }
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
-        $resolver
-            ->setDefaults(array('position' => null))
-            ->setAllowedTypes(array('position' => array('null', 'string', 'array')));
+        $this->configureOptions($resolver);
     }
 }

--- a/src/Extension/OrderedButtonExtension.php
+++ b/src/Extension/OrderedButtonExtension.php
@@ -24,6 +24,8 @@ class OrderedButtonExtension extends AbstractOrderedExtension
     */
     public function getExtendedType()
     {
-        return 'button';
+        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Symfony\Component\Form\Extension\Core\Type\ButtonType'
+            : 'button';
     }
 }

--- a/src/Extension/OrderedFormExtension.php
+++ b/src/Extension/OrderedFormExtension.php
@@ -23,6 +23,8 @@ class OrderedFormExtension extends AbstractOrderedExtension
      */
     public function getExtendedType()
     {
-        return 'form';
+        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Symfony\Component\Form\Extension\Core\Type\FormType'
+            : 'form';
     }
 }

--- a/src/OrderedResolvedFormType.php
+++ b/src/OrderedResolvedFormType.php
@@ -32,7 +32,7 @@ use Symfony\Component\Form\SubmitButtonTypeInterface;
  */
 class OrderedResolvedFormType extends ResolvedFormType
 {
-    /** @var \Ivory\OrderedForm\Model\FormOrdererInterface */
+    /** @var \Ivory\OrderedForm\Orderer\FormOrdererInterface */
     private $orderer;
 
     /**

--- a/tests/Extension/OrderedExtensionTest.php
+++ b/tests/Extension/OrderedExtensionTest.php
@@ -52,9 +52,11 @@ class OrderedExtensionTest extends \PHPUnit_Framework_TestCase
      */
     public function formTypeProvider()
     {
+        $fqcn = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix');
+
         return array(
-            array('text'),
-            array('button'),
+            array($fqcn ? 'Symfony\Component\Form\Extension\Core\Type\TextType' : 'text'),
+            array($fqcn ? 'Symfony\Component\Form\Extension\Core\Type\ButtonType' : 'button'),
         );
     }
 

--- a/tests/Fixtures/ExtraViewChildrenExtension.php
+++ b/tests/Fixtures/ExtraViewChildrenExtension.php
@@ -50,6 +50,8 @@ class ExtraViewChildrenExtension extends AbstractTypeExtension
      */
     public function getExtendedType()
     {
-        return 'form';
+        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Symfony\Component\Form\Extension\Core\Type\FormType'
+            : 'form';
     }
 }

--- a/tests/OrderedFormFunctionnalTest.php
+++ b/tests/OrderedFormFunctionnalTest.php
@@ -76,12 +76,16 @@ class OrderedFormFunctionnalTest extends \PHPUnit_Framework_TestCase
 
     public function testExtraViewChild()
     {
+        $type = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Symfony\Component\Form\Extension\Core\Type\FormType'
+            : 'form';
+
         $view = $this->factoryBuilder
             ->addTypeExtension(new ExtraViewChildrenExtension(array('extra1', 'extra2')))
             ->getFormFactory()
             ->createBuilder()
-            ->add('foo', 'form', array('position' => 'last'))
-            ->add('bar', 'form', array('position' => 'first'))
+            ->add('foo', $type, array('position' => 'last'))
+            ->add('bar', $type, array('position' => 'first'))
             ->getForm()
             ->createView();
 
@@ -372,12 +376,15 @@ class OrderedFormFunctionnalTest extends \PHPUnit_Framework_TestCase
     private function createForm(array $config)
     {
         $builder = $this->factory->createBuilder();
+        $type = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Symfony\Component\Form\Extension\Core\Type\FormType'
+            : 'form';
 
         foreach ($config as $name => $value) {
             if ((is_string($value) && is_string($name)) || is_array($value)) {
-                $builder->add($name, 'form', array('position' => $value));
+                $builder->add($name, $type, array('position' => $value));
             } else {
-                $builder->add($value, 'form');
+                $builder->add($value, $type);
             }
         }
 

--- a/tests/OrderedResolvedFormTypeFactoryTest.php
+++ b/tests/OrderedResolvedFormTypeFactoryTest.php
@@ -65,10 +65,10 @@ class OrderedResolvedFormTypeFactoryTest extends \PHPUnit_Framework_TestCase
     /**
      * Creates a form type.
      *
-     * @return \Symfony\Component\Form\FormTypeInterface The form type.
+     * @return \Symfony\Component\Form\AbstractType The form type.
      */
     private function createFormType()
     {
-        return $this->getMock('Symfony\Component\Form\FormTypeInterface');
+        return $this->getMock('Symfony\Component\Form\AbstractType');
     }
 }

--- a/tests/OrderedResolvedFormTypeTest.php
+++ b/tests/OrderedResolvedFormTypeTest.php
@@ -59,7 +59,7 @@ class OrderedResolvedFormTypeTest extends \PHPUnit_Framework_TestCase
 
     public function testCreateBuilderWithButtonInnerType()
     {
-        $innerType = $this->getMock('Symfony\Component\Form\ButtonTypeInterface');
+        $innerType = $this->getMock('Symfony\Component\Form\Extension\Core\Type\ButtonType');
 
         $this->type = new OrderedResolvedFormType(
             new FormOrderer(),
@@ -76,7 +76,7 @@ class OrderedResolvedFormTypeTest extends \PHPUnit_Framework_TestCase
 
     public function testCreateBuilderWithSubmitButtonInnerType()
     {
-        $innerType = $this->getMock('Symfony\Component\Form\SubmitButtonTypeInterface');
+        $innerType = $this->getMock('Symfony\Component\Form\Extension\Core\Type\SubmitType');
 
         $this->type = new OrderedResolvedFormType(
             new FormOrderer(),
@@ -111,11 +111,11 @@ class OrderedResolvedFormTypeTest extends \PHPUnit_Framework_TestCase
     /**
      * Creates a form type mock.
      *
-     * @return \Symfony\Component\Form\FormTypeInterface The form type mock.
+     * @return \Symfony\Component\Form\AbstractType The form type mock.
      */
     private function createMockFormType()
     {
-        return $this->getMock('Symfony\Component\Form\FormTypeInterface');
+        return $this->getMock('Symfony\Component\Form\AbstractType');
     }
 
     /**


### PR DESCRIPTION
This PR makes the base code compatible with Symfony3. The best choice seems to relies on method presence check.