### PR TITLE
Allow usage with Symfony 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,18 @@ matrix:
           env: SYMFONY_VERSION=3.2.*
         - php: 5.6
           env: SYMFONY_VERSION=3.3.*@dev
+        - php: 7.1
+          env: SYMFONY_VERSION=4.* COMPOSER_PREFER_LOWEST=true
+        - php: 7.2
+          env: SYMFONY_VERSION=4.* COMPOSER_PREFER_LOWEST=true
+        - php: 7.3
+          env: SYMFONY_VERSION=4.* COMPOSER_PREFER_LOWEST=true
+        - php: 7.1
+          env: SYMFONY_VERSION=4.*
+        - php: 7.2
+          env: SYMFONY_VERSION=4.*
+        - php: 7.3
+          env: SYMFONY_VERSION=4.*
     allow_failures:
         - env: SYMFONY_VERSION=3.3.*@dev
 

--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,12 @@
     ],
     "require": {
         "php": "^5.6|^7.0",
-        "symfony/form": "^2.7|^3.0"
+        "symfony/form": "^2.7|^3.0|^4.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.0",
         "phpunit/phpunit": "^5.0",
-        "symfony/phpunit-bridge": "^2.7|^3.0"
+        "symfony/phpunit-bridge": "^2.7|^3.0|^4.0"
     },
     "autoload": {
         "psr-4": { "Ivory\\OrderedForm\\": "src/" }


### PR DESCRIPTION
It seems that this package is in fact compatible with Symfony 4 already, so it should be enoughto change its requirements in `composer.json`. I've created this little PR to add the support. It will be incompatible with Symfony 5 though due to changes in `FormTypeExtensionInterface`.

I've added some jobs to the Travis build to support my claims. Builds on Symfony >=4.2 fail due to deprecations - it succeeds on 4.0 and Symfony is pretty good with keeping backward compatibility. Jobs with hhvm and Docker fail even on current `master` (see build of bd2cd20 in [my fork](https://travis-ci.org/PetrHeinz/ivory-ordered-form/builds/508956645) or restart the build yourself).

Are you still able to merge and release a new version (`3.1.0`, I'd suppose), or is this project no longer maintained? Can I help? Thanks :slightly_smiling_face: 